### PR TITLE
Remove Iosevka from cspell.json

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -116,7 +116,6 @@
     "inkarkat",
     "inoremap",
     "invisibles",
-    "iosevka",
     "ircs",
     "isdirectory",
     "iskeyword",


### PR DESCRIPTION
Iosevka was added to the cspell font library in [this pr](https://github.com/streetsidesoftware/cspell-dicts/pull/2094)
