### PR TITLE
Update prepare-commit-msg hook

### DIFF
--- a/config/git/hooks/prepare-commit-msg
+++ b/config/git/hooks/prepare-commit-msg
@@ -30,4 +30,44 @@ if [[ -n "$jira_tag_id" ]]; then
 
 	# if command is set, prepend jira issue id to the commit message
 	[[ -n $command ]] && sed -i.bak -e "$command" "$COMMIT_MSG_FILE"
+
+	return
+fi
+
+conventional_commit_types=(
+	"build"
+	"chore"
+	"ci"
+	"docs"
+	"feat"
+	"fix"
+	"perf"
+	"refactor"
+	"revert"
+	"style"
+	"test"
+)
+
+# check if branch has conventional commit type before /
+branch_slug=$(echo "$branch_name" | sed -nr 's,([a-z]+)/?.+,\1,p')
+
+# check if branch_slug is in conventional_commit_types
+[[ "${conventional_commit_types[*]}" =~ $branch_slug ]] && conventional_commit_type=$branch_slug
+
+if [[ -n "$conventional_commit_type" ]]; then
+	# exit if conventional_commit_type is found already in the commit message
+    grep -q "^$conventional_commit_type(\(\w*\))?:" "$COMMIT_MSG_FILE" && exit 0
+
+	printf "\n Prepending conventional commit type to commit message...\n\n"
+
+	# check  if commit was initiated with editor/template
+	if [[ "$COMMIT_SOURCE" == "template" ]]; then
+		command="0,/^$/{s/^$/$conventional_commit_type(): /}"
+	else
+		# ...or with -m flag
+		command="1s/^/$conventional_commit_type: /"
+	fi
+
+	# if command is set, prepend conventional commit type to the commit message
+	[[ -n $command ]] && sed -i.bak -e "$command" "$COMMIT_MSG_FILE"
 fi


### PR DESCRIPTION
- hook will now check for conventional commit types before `/` in the branch name
